### PR TITLE
Power lim report

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "authlib",
     "requests",
     "pyjwt",
-    "cactus-schema>=0.0.17",
+    "cactus-schema>=0.0.18",
     "cactus-test-definitions",  # used only for determining witness test class membership for HTML report display
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "authlib",
     "requests",
     "pyjwt",
-    "cactus-schema>=0.0.15",
+    "cactus-schema>=0.0.17",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "requests",
     "pyjwt",
     "cactus-schema>=0.0.17",
+    "cactus-test-definitions",  # used only for determining witness test class membership for HTML report display
 ]
 
 

--- a/src/cactus_ui/orchestrator.py
+++ b/src/cactus_ui/orchestrator.py
@@ -348,7 +348,9 @@ def fetch_run_artifact(access_token: str, run_id: str) -> tuple[bytes | None, st
     return (response.content, generate_run_artifact_file_name(response, run_id))
 
 
-def fetch_run_power_limit_chart(access_token: str, run_id: int, video_start_seconds: float | None = None) -> tuple[str | None, str | None]:
+def fetch_run_power_limit_chart(
+    access_token: str, run_id: int, video_start_seconds: float | None = None
+) -> tuple[str | None, str | None]:
     """Fetch the power limit HTML chart for a run. Returns (html, error_detail)."""
     uri = generate_uri(orchestrator.uri.RunPowerLimitChart.format(run_id=run_id))
     if video_start_seconds is not None:
@@ -676,7 +678,9 @@ def admin_fetch_run_artifact(access_token: str, run_id: str) -> tuple[bytes | No
     return (response.content, generate_run_artifact_file_name(response, run_id))
 
 
-def admin_fetch_run_power_limit_chart(access_token: str, run_id: int, video_start_seconds: float | None = None) -> str | None:
+def admin_fetch_run_power_limit_chart(
+    access_token: str, run_id: int, video_start_seconds: float | None = None
+) -> str | None:
     """Admin: fetch the power limit HTML chart for a run. Returns HTML string or None on failure."""
     uri = generate_uri(orchestrator.uri.AdminRunPowerLimitChart.format(run_id=run_id))
     if video_start_seconds is not None:

--- a/src/cactus_ui/orchestrator.py
+++ b/src/cactus_ui/orchestrator.py
@@ -318,18 +318,11 @@ def start_run(access_token: str, run_id: str) -> StartResult:
         return StartResult(success=False, error_message="Unexpected error when attempting to start the run.")
 
 
-def finalise_run(access_token: str, run_id: str) -> bytes | None:
-    """Given an already started run - finalise it and return the resulting ZIP file bytes"""
+def finalise_run(access_token: str, run_id: str) -> bool:
+    """Finalise a run. Returns True on success, False on error."""
     uri = generate_uri(orchestrator.uri.RunFinalise.format(run_id=run_id))
     response = safe_request("POST", uri, generate_headers(access_token), CACTUS_ORCHESTRATOR_REQUEST_TIMEOUT_DEFAULT)
-    if response is None or not is_success_response(response):
-        return None
-
-    # This is a special case - we DID finalize but got no data due to a downstream error. Treat it as a general failure.
-    if response.status_code == HTTPStatus.NO_CONTENT:
-        return None
-
-    return response.content
+    return response is not None and is_success_response(response)
 
 
 def finalise_playlist(access_token: str, run_id: str) -> bytes | None:
@@ -355,13 +348,19 @@ def fetch_run_artifact(access_token: str, run_id: str) -> tuple[bytes | None, st
     return (response.content, generate_run_artifact_file_name(response, run_id))
 
 
-def fetch_run_power_limit_chart(access_token: str, run_id: int) -> str | None:
-    """Fetch the power limit HTML chart for a run. Returns HTML string or None on failure."""
+def fetch_run_power_limit_chart(access_token: str, run_id: int) -> tuple[str | None, str | None]:
+    """Fetch the power limit HTML chart for a run. Returns (html, error_detail)."""
     uri = generate_uri(orchestrator.uri.RunPowerLimitChart.format(run_id=run_id))
     response = safe_request("GET", uri, generate_headers(access_token), CACTUS_ORCHESTRATOR_REQUEST_TIMEOUT_LONG)
-    if response is None or not is_success_response(response):
-        return None
-    return response.text
+    if response is None:
+        return (None, None)
+    if not is_success_response(response):
+        try:
+            detail = response.json().get("detail", None)
+        except Exception:
+            detail = None
+        return (None, detail)
+    return (response.text, None)
 
 
 def fetch_multiple_run_artifacts(access_token: str, run_ids: list[int]) -> bytes | None:

--- a/src/cactus_ui/orchestrator.py
+++ b/src/cactus_ui/orchestrator.py
@@ -19,6 +19,7 @@ if ENV_FILE:
 # envvars
 CACTUS_ORCHESTRATOR_BASEURL = env["CACTUS_ORCHESTRATOR_BASEURL"]
 CACTUS_ORCHESTRATOR_REQUEST_TIMEOUT_DEFAULT = int(env.get("CACTUS_ORCHESTRATOR_REQUEST_TIMEOUT_DEFAULT", "30"))
+CACTUS_ORCHESTRATOR_REQUEST_TIMEOUT_LONG = int(env.get("CACTUS_ORCHESTRATOR_REQUEST_TIMEOUT_LONG", "120"))
 CACTUS_ORCHESTRATOR_REQUEST_TIMEOUT_SPAWN = int(env.get("CACTUS_ORCHESTRATOR_REQUEST_TIMEOUT_SPAWN", "120"))
 
 
@@ -354,6 +355,15 @@ def fetch_run_artifact(access_token: str, run_id: str) -> tuple[bytes | None, st
     return (response.content, generate_run_artifact_file_name(response, run_id))
 
 
+def fetch_run_power_limit_chart(access_token: str, run_id: int) -> str | None:
+    """Fetch the power limit HTML chart for a run. Returns HTML string or None on failure."""
+    uri = generate_uri(orchestrator.uri.RunPowerLimitChart.format(run_id=run_id))
+    response = safe_request("GET", uri, generate_headers(access_token), CACTUS_ORCHESTRATOR_REQUEST_TIMEOUT_LONG)
+    if response is None or not is_success_response(response):
+        return None
+    return response.text
+
+
 def fetch_multiple_run_artifacts(access_token: str, run_ids: list[int]) -> bytes | None:
     """Fetch artifacts for multiple runs as a single ZIP file"""
     uri = generate_uri("/run/artifact/multiple")
@@ -663,6 +673,15 @@ def admin_fetch_run_artifact(access_token: str, run_id: str) -> tuple[bytes | No
         return (None, "")
 
     return (response.content, generate_run_artifact_file_name(response, run_id))
+
+
+def admin_fetch_run_power_limit_chart(access_token: str, run_id: int) -> str | None:
+    """Admin: fetch the power limit HTML chart for a run. Returns HTML string or None on failure."""
+    uri = generate_uri(orchestrator.uri.AdminRunPowerLimitChart.format(run_id=run_id))
+    response = safe_request("GET", uri, generate_headers(access_token), CACTUS_ORCHESTRATOR_REQUEST_TIMEOUT_LONG)
+    if response is None or not is_success_response(response):
+        return None
+    return response.text
 
 
 def admin_fetch_run_group_artifact(access_token: str, run_group_id: int) -> bytes | None:

--- a/src/cactus_ui/orchestrator.py
+++ b/src/cactus_ui/orchestrator.py
@@ -348,9 +348,11 @@ def fetch_run_artifact(access_token: str, run_id: str) -> tuple[bytes | None, st
     return (response.content, generate_run_artifact_file_name(response, run_id))
 
 
-def fetch_run_power_limit_chart(access_token: str, run_id: int) -> tuple[str | None, str | None]:
+def fetch_run_power_limit_chart(access_token: str, run_id: int, video_start_seconds: float | None = None) -> tuple[str | None, str | None]:
     """Fetch the power limit HTML chart for a run. Returns (html, error_detail)."""
     uri = generate_uri(orchestrator.uri.RunPowerLimitChart.format(run_id=run_id))
+    if video_start_seconds is not None:
+        uri = f"{uri}?video_start_seconds={video_start_seconds}"
     response = safe_request("GET", uri, generate_headers(access_token), CACTUS_ORCHESTRATOR_REQUEST_TIMEOUT_LONG)
     if response is None:
         return (None, None)
@@ -674,9 +676,11 @@ def admin_fetch_run_artifact(access_token: str, run_id: str) -> tuple[bytes | No
     return (response.content, generate_run_artifact_file_name(response, run_id))
 
 
-def admin_fetch_run_power_limit_chart(access_token: str, run_id: int) -> str | None:
+def admin_fetch_run_power_limit_chart(access_token: str, run_id: int, video_start_seconds: float | None = None) -> str | None:
     """Admin: fetch the power limit HTML chart for a run. Returns HTML string or None on failure."""
     uri = generate_uri(orchestrator.uri.AdminRunPowerLimitChart.format(run_id=run_id))
+    if video_start_seconds is not None:
+        uri = f"{uri}?video_start_seconds={video_start_seconds}"
     response = safe_request("GET", uri, generate_headers(access_token), CACTUS_ORCHESTRATOR_REQUEST_TIMEOUT_LONG)
     if response is None or not is_success_response(response):
         return None

--- a/src/cactus_ui/server.py
+++ b/src/cactus_ui/server.py
@@ -594,11 +594,34 @@ def admin_run_status_page(access_token: str, run_id: str) -> str | Response:
     )
 
 
+def _parse_video_start(raw: str | None) -> float | None:
+    """Parse a video timestamp string ('SS', 'M:SS', 'MM:SS', 'H:MM:SS') to seconds.
+
+    Returns None if the input is absent, empty, or cannot be parsed — callers treat
+    None as "no offset" and generate the chart with the default test-relative axis.
+    """
+    if not raw:
+        return None
+    parts = raw.strip().split(":")
+    try:
+        nums = [float(p) for p in parts]
+    except ValueError:
+        return None
+    if len(nums) == 1:
+        return nums[0]
+    if len(nums) == 2:
+        return nums[0] * 60 + nums[1]
+    if len(nums) == 3:
+        return nums[0] * 3600 + nums[1] * 60 + nums[2]
+    return None
+
+
 @app.route("/admin/run/<int:run_id>/html_report", methods=["GET"])
 @login_required
 @admin_role_required
 def admin_run_html_report_page(access_token: str, run_id: int) -> str | Response:
-    html = orchestrator.admin_fetch_run_power_limit_chart(access_token, run_id)
+    video_start = _parse_video_start(request.args.get("video_start"))
+    html = orchestrator.admin_fetch_run_power_limit_chart(access_token, run_id, video_start_seconds=video_start)
     if html is None:
         return Response(response="Failed to generate HTML report.", status=HTTPStatus.BAD_GATEWAY)
     return Response(html, mimetype="text/html")
@@ -1434,7 +1457,8 @@ def _handle_run_status_post(access_token: str, run_id: str) -> str | Response | 
 @app.route("/run/<int:run_id>/html_report", methods=["GET"])
 @login_required
 def run_html_report_page(access_token: str, run_id: int) -> str | Response:
-    html, error_detail = orchestrator.fetch_run_power_limit_chart(access_token, run_id)
+    video_start = _parse_video_start(request.args.get("video_start"))
+    html, error_detail = orchestrator.fetch_run_power_limit_chart(access_token, run_id, video_start_seconds=video_start)
     if html is None:
         message = error_detail or "Failed to generate HTML report."
         return Response(response=message, status=HTTPStatus.BAD_GATEWAY)

--- a/src/cactus_ui/server.py
+++ b/src/cactus_ui/server.py
@@ -17,6 +17,8 @@ from pathlib import Path
 from typing import Any, Callable, TypeVar, cast
 from urllib.parse import quote_plus, urlencode
 from cactus_schema.orchestrator.compliance import fetch_compliance_classes
+# cactus_test_definitions is imported only for witness test class membership used in HTML report display
+from cactus_test_definitions.client.test_procedures import get_all_test_procedures
 
 import cactus_schema.orchestrator as schema
 import jwt
@@ -50,6 +52,11 @@ else:
     logging.basicConfig(level=logging.INFO)
 
 logger = logging.getLogger(__name__)
+
+_WITNESS_CLASSES = frozenset({"DER-A", "DER-G", "DER-L", "DR-A", "DR-D", "DR-G", "DR-L"})
+_WITNESS_PROCEDURE_IDS: frozenset[str] = frozenset(
+    str(pid) for pid, tp in get_all_test_procedures().items() if _WITNESS_CLASSES & set(tp.classes)
+)
 
 
 ENV_FILE = find_dotenv()
@@ -581,6 +588,7 @@ def admin_run_status_page(access_token: str, run_id: str) -> str | Response:
         error=error,
         playlist_info=None,
         is_admin_view=True,
+        is_witness_test=run_procedure_id in _WITNESS_PROCEDURE_IDS,
         user_buttons_state="disabled",
         cactus_platform_support_email=CACTUS_PLATFORM_SUPPORT_EMAIL,
     )
@@ -1480,6 +1488,7 @@ def run_status_page(access_token: str, run_id: str) -> str | Response:
         next_playlist_run_id=next_playlist_run_id,
         current_active_run=current_active_run,
         is_admin_view=False,
+        is_witness_test=run_procedure_id in _WITNESS_PROCEDURE_IDS,
         cactus_platform_support_email=CACTUS_PLATFORM_SUPPORT_EMAIL,
     )
 

--- a/src/cactus_ui/server.py
+++ b/src/cactus_ui/server.py
@@ -586,6 +586,16 @@ def admin_run_status_page(access_token: str, run_id: str) -> str | Response:
     )
 
 
+@app.route("/admin/run/<int:run_id>/html_report", methods=["GET"])
+@login_required
+@admin_role_required
+def admin_run_html_report_page(access_token: str, run_id: int) -> str | Response:
+    html = orchestrator.admin_fetch_run_power_limit_chart(access_token, run_id)
+    if html is None:
+        return Response(response="Failed to generate HTML report.", status=HTTPStatus.BAD_GATEWAY)
+    return Response(html, mimetype="text/html")
+
+
 @app.route("/admin/run/<int:run_id>/status", methods=["GET"])
 @login_required
 @admin_role_required
@@ -1427,6 +1437,15 @@ def _handle_run_status_post(access_token: str, run_id: str) -> str | Response | 
     return None
 
 
+@app.route("/run/<int:run_id>/html_report", methods=["GET"])
+@login_required
+def run_html_report_page(access_token: str, run_id: int) -> str | Response:
+    html = orchestrator.fetch_run_power_limit_chart(access_token, run_id)
+    if html is None:
+        return Response(response="Failed to generate HTML report.", status=HTTPStatus.BAD_GATEWAY)
+    return Response(html, mimetype="text/html")
+
+
 @app.route("/run/<int:run_id>", methods=["GET", "POST"])
 @login_required
 def run_status_page(access_token: str, run_id: str) -> str | Response:
@@ -1473,6 +1492,7 @@ def run_status_page(access_token: str, run_id: str) -> str | Response:
         playlist_info=playlist_info,
         next_playlist_run_id=next_playlist_run_id,
         current_active_run=current_active_run,
+        is_admin_view=False,
         cactus_platform_support_email=CACTUS_PLATFORM_SUPPORT_EMAIL,
     )
 

--- a/src/cactus_ui/server.py
+++ b/src/cactus_ui/server.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any, Callable, TypeVar, cast
 from urllib.parse import quote_plus, urlencode
 from cactus_schema.orchestrator.compliance import fetch_compliance_classes
+
 # cactus_test_definitions is imported only for witness test class membership used in HTML report display
 from cactus_test_definitions.client.test_procedures import get_all_test_procedures
 

--- a/src/cactus_ui/server.py
+++ b/src/cactus_ui/server.py
@@ -54,7 +54,7 @@ else:
 
 logger = logging.getLogger(__name__)
 
-_WITNESS_CLASSES = frozenset({"DER-A", "DER-G", "DER-L", "DR-A", "DR-D", "DR-G", "DR-L"})
+_WITNESS_CLASSES = frozenset({"DER-A", "DER-G", "DER-L", "DR-D", "DR-G", "DR-L"})
 _WITNESS_PROCEDURE_IDS: frozenset[str] = frozenset(
     str(pid) for pid, tp in get_all_test_procedures().items() if _WITNESS_CLASSES & set(tp.classes)
 )

--- a/src/cactus_ui/server.py
+++ b/src/cactus_ui/server.py
@@ -916,16 +916,8 @@ def group_runs_page(access_token: str, run_group_id: int) -> str | Response:  # 
             if not run_id:
                 error = "No run ID specified."
             else:
-                archive_data = orchestrator.finalise_run(access_token, run_id)
-                if archive_data is None:
-                    error = "Failed to finalise the run or retrieve artifacts."
-                else:
-                    return send_file(
-                        io.BytesIO(archive_data),
-                        as_attachment=True,
-                        download_name=f"{run_id}_artifacts.zip",
-                        mimetype="application/zip",
-                    )
+                if not orchestrator.finalise_run(access_token, run_id):
+                    error = "Failed to finalise the run."
 
         # Handle dl artifact
         elif request.form.get("action") == "artifact":
@@ -1403,15 +1395,9 @@ def _handle_run_status_post(access_token: str, run_id: str) -> str | Response | 
             )
         return None
     elif action == "finalise":
-        archive_data = orchestrator.finalise_run(access_token, run_id)
-        if archive_data is None:
-            return "Failed to finalise the run or retrieve artifacts."
-        return send_file(
-            io.BytesIO(archive_data),
-            as_attachment=True,
-            download_name=f"{run_id}_artifacts.zip",
-            mimetype="application/zip",
-        )
+        if not orchestrator.finalise_run(access_token, run_id):
+            return "Failed to finalise the run."
+        return None
     elif action == "artifact":
         artifact_data, download_name = orchestrator.fetch_run_artifact(access_token, run_id)
         if artifact_data is None:
@@ -1440,9 +1426,10 @@ def _handle_run_status_post(access_token: str, run_id: str) -> str | Response | 
 @app.route("/run/<int:run_id>/html_report", methods=["GET"])
 @login_required
 def run_html_report_page(access_token: str, run_id: int) -> str | Response:
-    html = orchestrator.fetch_run_power_limit_chart(access_token, run_id)
+    html, error_detail = orchestrator.fetch_run_power_limit_chart(access_token, run_id)
     if html is None:
-        return Response(response="Failed to generate HTML report.", status=HTTPStatus.BAD_GATEWAY)
+        message = error_detail or "Failed to generate HTML report."
+        return Response(response=message, status=HTTPStatus.BAD_GATEWAY)
     return Response(html, mimetype="text/html")
 
 

--- a/src/cactus_ui/templates/run_status.html
+++ b/src/cactus_ui/templates/run_status.html
@@ -232,6 +232,35 @@
         </div>
     </div>
 </div>
+
+<div class="modal fade" id="powerChartModal" tabindex="-1" aria-labelledby="powerChartModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="powerChartModalLabel">View Device Power Chart</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <p>Would you like to align the time axis to a video recording of the test?</p>
+                <p>Enter the video timestamp at which the test started.</p>
+                <div class="d-flex align-items-center gap-2">
+                    <label class="form-label mb-0 text-nowrap" for="powerChartMins">Video timestamp:</label>
+                    <input type="number" id="powerChartMins" class="form-control form-control-sm" style="width:70px;"
+                           min="0" placeholder="MM" aria-label="Minutes">
+                    <span>:</span>
+                    <input type="number" id="powerChartSecs" class="form-control form-control-sm" style="width:70px;"
+                           min="0" max="59" placeholder="SS" aria-label="Seconds">
+                </div>
+                <div class="form-text">Leave blank to use test-relative time.</div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-primary" id="powerChartOpenBtn">View Report</button>
+            </div>
+        </div>
+    </div>
+</div>
+
 <br>
 <div class="row justify-content-center">
     <div class="card status-container ">
@@ -291,14 +320,11 @@
                     <button type="submit" class="btn btn-primary">Download Artifacts</button>
                 </form>
                 {% if is_witness_test %}
-                <form action="{{ url_for('admin_run_html_report_page' if is_admin_view else 'run_html_report_page', run_id=run_id) }}"
-                      method="GET" target="_blank" class="d-flex gap-1 align-items-center">
-                  <input type="text" name="video_start"
-                         placeholder="Video offset (MM:SS)"
-                         title="Optional: enter the video timestamp (MM:SS or H:MM:SS) at which the test started. Leave blank for test-relative time. Invalid values are ignored."
-                         class="form-control form-control-sm" style="width:165px;">
-                  <button type="submit" class="btn btn-outline-secondary">View Device Power Chart</button>
-                </form>
+                <button type="button" class="btn btn-outline-secondary"
+                        data-bs-toggle="modal" data-bs-target="#powerChartModal"
+                        data-report-url="{{ url_for('admin_run_html_report_page' if is_admin_view else 'run_html_report_page', run_id=run_id) }}">
+                    View Device Power Chart
+                </button>
                 {% endif %}
             </div>
         </div>
@@ -1894,6 +1920,21 @@
             const pollRateMs = 10000; // 10 seconds
             startPollingRunStatus(uri, pollRateMs);
         }
+
+        // Power chart modal — wire up "View Report" button
+        document.getElementById('powerChartOpenBtn')?.addEventListener('click', () => {
+            const triggerBtn = document.querySelector('[data-bs-target="#powerChartModal"]');
+            const baseUrl = triggerBtn?.dataset.reportUrl;
+            if (!baseUrl) return;
+
+            const mins = parseInt(document.getElementById('powerChartMins').value) || 0;
+            const secs = parseInt(document.getElementById('powerChartSecs').value) || 0;
+            const totalSeconds = mins * 60 + secs;
+
+            const url = totalSeconds > 0 ? `${baseUrl}?video_start=${mins}:${String(secs).padStart(2, '0')}` : baseUrl;
+            window.open(url, '_blank');
+            bootstrap.Modal.getInstance(document.getElementById('powerChartModal'))?.hide();
+        });
     });
 
 

--- a/src/cactus_ui/templates/run_status.html
+++ b/src/cactus_ui/templates/run_status.html
@@ -456,7 +456,7 @@
                 if (nextRunId) {
                     window.location.href = `/run/${nextRunId}`;
                 } else {
-                    window.location.reload();
+                    window.location.replace(window.location.pathname);
                 }
             } else {
                 alert('Failed to finalise the run. Please try again.');

--- a/src/cactus_ui/templates/run_status.html
+++ b/src/cactus_ui/templates/run_status.html
@@ -255,7 +255,8 @@
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-                <button type="button" class="btn btn-primary" id="powerChartOpenBtn">View Report</button>
+                <button type="button" class="btn btn-primary" id="powerChartOpenBtn"
+                        data-report-url="{{ url_for('admin_run_html_report_page' if is_admin_view else 'run_html_report_page', run_id=run_id) }}">View Report</button>
             </div>
         </div>
     </div>
@@ -1922,11 +1923,8 @@
         }
 
         // Power chart modal — wire up "View Report" button
-        document.getElementById('powerChartOpenBtn')?.addEventListener('click', () => {
-            const triggerBtn = document.querySelector('[data-bs-target="#powerChartModal"]');
-            const baseUrl = triggerBtn?.dataset.reportUrl;
-            if (!baseUrl) return;
-
+        document.getElementById('powerChartOpenBtn')?.addEventListener('click', function() {
+            const baseUrl = this.dataset.reportUrl;
             const mins = parseInt(document.getElementById('powerChartMins').value) || 0;
             const secs = parseInt(document.getElementById('powerChartSecs').value) || 0;
             const totalSeconds = mins * 60 + secs;

--- a/src/cactus_ui/templates/run_status.html
+++ b/src/cactus_ui/templates/run_status.html
@@ -293,7 +293,7 @@
                 </form>
                 {% if is_witness_test %}
                 <details>
-                    <summary class="btn btn-outline-secondary">View Device Power Chart</summary>
+                    <summary class="btn btn-outline-secondary">Witness Test Chart</summary>
                     <form action="{{ url_for('admin_run_html_report_page' if is_admin_view else 'run_html_report_page', run_id=run_id) }}"
                           method="GET" target="_blank"
                           class="mt-2 p-3 border rounded bg-light d-flex flex-column gap-2" style="width: 280px;">
@@ -304,7 +304,7 @@
                                    class="form-control form-control-sm" style="width:90px;"
                                    placeholder="MM:SS" autocomplete="off">
                         </div>
-                        <button type="submit" class="btn btn-outline-secondary btn-sm align-self-start">Open Report</button>
+                        <button type="submit" class="btn btn-outline-secondary btn-sm align-self-start">Create Chart</button>
                     </form>
                 </details>
                 {% endif %}

--- a/src/cactus_ui/templates/run_status.html
+++ b/src/cactus_ui/templates/run_status.html
@@ -452,29 +452,9 @@
             });
 
             if (response.ok) {
-                // Download the ZIP file
-                const blob = await response.blob();
-                const contentDisposition = response.headers.get('Content-Disposition');
-                let filename = 'artifacts.zip';
-                if (contentDisposition) {
-                    const match = contentDisposition.match(/filename="?([^";\n]+)"?/);
-                    if (match) filename = match[1];
-                }
-
-                const url = window.URL.createObjectURL(blob);
-                const a = document.createElement('a');
-                a.href = url;
-                a.download = filename;
-                document.body.appendChild(a);
-                a.click();
-                window.URL.revokeObjectURL(url);
-                a.remove();
-
                 // Redirect to next run in playlist, or reload to show completed state
                 if (nextRunId) {
-                    setTimeout(() => {
-                        window.location.href = `/run/${nextRunId}`;
-                    }, 500);
+                    window.location.href = `/run/${nextRunId}`;
                 } else {
                     window.location.reload();
                 }

--- a/src/cactus_ui/templates/run_status.html
+++ b/src/cactus_ui/templates/run_status.html
@@ -284,11 +284,18 @@
         <div class="alert alert-primary" role="alert">
             <p>This run has been finalised and is no longer active.</p>
 
-            <p>Click the button below to download the run's artifacts.</p>
-            <form id='download-form' method="POST" action="{{ url_for('run_status_page', run_id=run_id) }}">
-                <input type="hidden" name="action" value="artifact">
-                <button type="submit" class="btn btn-primary">Download Artifacts</button>
-            </form>
+            <p>Click the buttons below to download the run's artifacts or view the HTML report.</p>
+            <div class="d-flex gap-2 flex-wrap">
+                <form id='download-form' method="POST" action="{{ url_for('admin_run_status_page', run_id=run_id) if is_admin_view else url_for('run_status_page', run_id=run_id) }}">
+                    <input type="hidden" name="action" value="artifact">
+                    <button type="submit" class="btn btn-primary">Download Artifacts</button>
+                </form>
+                {% if is_admin_view %}
+                <a href="{{ url_for('admin_run_html_report_page', run_id=run_id) }}" target="_blank" class="btn btn-outline-secondary">View HTML Report</a>
+                {% else %}
+                <a href="{{ url_for('run_html_report_page', run_id=run_id) }}" target="_blank" class="btn btn-outline-secondary">View HTML Report</a>
+                {% endif %}
+            </div>
         </div>
         {% else %}
         <div class="alert alert-warning" role="alert">

--- a/src/cactus_ui/templates/run_status.html
+++ b/src/cactus_ui/templates/run_status.html
@@ -284,16 +284,18 @@
         <div class="alert alert-primary" role="alert">
             <p>This run has been finalised and is no longer active.</p>
 
-            <p>Click the buttons below to download the run's artifacts or view the HTML report.</p>
+            <p>Click below to download the run's artifacts{% if is_witness_test %} or view the Device Power Chart{% endif %}.</p>
             <div class="d-flex gap-2 flex-wrap">
                 <form id='download-form' method="POST" action="{{ url_for('admin_run_status_page', run_id=run_id) if is_admin_view else url_for('run_status_page', run_id=run_id) }}">
                     <input type="hidden" name="action" value="artifact">
                     <button type="submit" class="btn btn-primary">Download Artifacts</button>
                 </form>
+                {% if is_witness_test %}
                 {% if is_admin_view %}
-                <a href="{{ url_for('admin_run_html_report_page', run_id=run_id) }}" target="_blank" class="btn btn-outline-secondary">View HTML Report</a>
+                <a href="{{ url_for('admin_run_html_report_page', run_id=run_id) }}" target="_blank" class="btn btn-outline-secondary">View Device Power Chart</a>
                 {% else %}
-                <a href="{{ url_for('run_html_report_page', run_id=run_id) }}" target="_blank" class="btn btn-outline-secondary">View HTML Report</a>
+                <a href="{{ url_for('run_html_report_page', run_id=run_id) }}" target="_blank" class="btn btn-outline-secondary">View Device Power Chart</a>
+                {% endif %}
                 {% endif %}
             </div>
         </div>

--- a/src/cactus_ui/templates/run_status.html
+++ b/src/cactus_ui/templates/run_status.html
@@ -236,28 +236,27 @@
 <div class="modal fade" id="powerChartModal" tabindex="-1" aria-labelledby="powerChartModalLabel" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title" id="powerChartModalLabel">View Device Power Chart</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-            </div>
-            <div class="modal-body">
-                <p>Would you like to align the time axis to a video recording of the test?</p>
-                <p>Enter the video timestamp at which the test started.</p>
-                <div class="d-flex align-items-center gap-2">
-                    <label class="form-label mb-0 text-nowrap" for="powerChartMins">Video timestamp:</label>
-                    <input type="number" id="powerChartMins" class="form-control form-control-sm" style="width:70px;"
-                           min="0" placeholder="MM" aria-label="Minutes">
-                    <span>:</span>
-                    <input type="number" id="powerChartSecs" class="form-control form-control-sm" style="width:70px;"
-                           min="0" max="59" placeholder="SS" aria-label="Seconds">
+            <form action="{{ url_for('admin_run_html_report_page' if is_admin_view else 'run_html_report_page', run_id=run_id) }}"
+                  method="GET" target="_blank">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="powerChartModalLabel">View Device Power Chart</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
-                <div class="form-text">Leave blank to use test-relative time.</div>
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-                <button type="button" class="btn btn-primary" id="powerChartOpenBtn"
-                        data-report-url="{{ url_for('admin_run_html_report_page' if is_admin_view else 'run_html_report_page', run_id=run_id) }}">View Report</button>
-            </div>
+                <div class="modal-body">
+                    <p>Would you like to align the time axis to a video recording of the test?</p>
+                    <p>Enter the video timestamp (MM:SS) at which the test started, or leave blank for test-relative time.</p>
+                    <div class="d-flex align-items-center gap-2">
+                        <label class="form-label mb-0 text-nowrap" for="powerChartVideoStart">Video timestamp:</label>
+                        <input type="text" id="powerChartVideoStart" name="video_start"
+                               class="form-control form-control-sm" style="width:100px;"
+                               placeholder="MM:SS" autocomplete="off">
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-primary">View Report</button>
+                </div>
+            </form>
         </div>
     </div>
 </div>
@@ -1922,17 +1921,7 @@
             startPollingRunStatus(uri, pollRateMs);
         }
 
-        // Power chart modal — wire up "View Report" button
-        document.getElementById('powerChartOpenBtn')?.addEventListener('click', function() {
-            const baseUrl = this.dataset.reportUrl;
-            const mins = parseInt(document.getElementById('powerChartMins').value) || 0;
-            const secs = parseInt(document.getElementById('powerChartSecs').value) || 0;
-            const totalSeconds = mins * 60 + secs;
 
-            const url = totalSeconds > 0 ? `${baseUrl}?video_start=${mins}:${String(secs).padStart(2, '0')}` : baseUrl;
-            window.open(url, '_blank');
-            bootstrap.Modal.getInstance(document.getElementById('powerChartModal'))?.hide();
-        });
     });
 
 

--- a/src/cactus_ui/templates/run_status.html
+++ b/src/cactus_ui/templates/run_status.html
@@ -291,11 +291,14 @@
                     <button type="submit" class="btn btn-primary">Download Artifacts</button>
                 </form>
                 {% if is_witness_test %}
-                {% if is_admin_view %}
-                <a href="{{ url_for('admin_run_html_report_page', run_id=run_id) }}" target="_blank" class="btn btn-outline-secondary">View Device Power Chart</a>
-                {% else %}
-                <a href="{{ url_for('run_html_report_page', run_id=run_id) }}" target="_blank" class="btn btn-outline-secondary">View Device Power Chart</a>
-                {% endif %}
+                <form action="{{ url_for('admin_run_html_report_page' if is_admin_view else 'run_html_report_page', run_id=run_id) }}"
+                      method="GET" target="_blank" class="d-flex gap-1 align-items-center">
+                  <input type="text" name="video_start"
+                         placeholder="Video offset (MM:SS)"
+                         title="Optional: enter the video timestamp (MM:SS or H:MM:SS) at which the test started. Leave blank for test-relative time. Invalid values are ignored."
+                         class="form-control form-control-sm" style="width:165px;">
+                  <button type="submit" class="btn btn-outline-secondary">View Device Power Chart</button>
+                </form>
                 {% endif %}
             </div>
         </div>

--- a/src/cactus_ui/templates/run_status.html
+++ b/src/cactus_ui/templates/run_status.html
@@ -233,34 +233,6 @@
     </div>
 </div>
 
-<div class="modal fade" id="powerChartModal" tabindex="-1" aria-labelledby="powerChartModalLabel" aria-hidden="true">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <form action="{{ url_for('admin_run_html_report_page' if is_admin_view else 'run_html_report_page', run_id=run_id) }}"
-                  method="GET" target="_blank">
-                <div class="modal-header">
-                    <h5 class="modal-title" id="powerChartModalLabel">View Device Power Chart</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                </div>
-                <div class="modal-body">
-                    <p>Would you like to align the time axis to a video recording of the test?</p>
-                    <p>Enter the video timestamp (MM:SS) at which the test started, or leave blank for test-relative time.</p>
-                    <div class="d-flex align-items-center gap-2">
-                        <label class="form-label mb-0 text-nowrap" for="powerChartVideoStart">Video timestamp:</label>
-                        <input type="text" id="powerChartVideoStart" name="video_start"
-                               class="form-control form-control-sm" style="width:100px;"
-                               placeholder="MM:SS" autocomplete="off">
-                    </div>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-                    <button type="submit" class="btn btn-primary">View Report</button>
-                </div>
-            </form>
-        </div>
-    </div>
-</div>
-
 <br>
 <div class="row justify-content-center">
     <div class="card status-container ">
@@ -320,11 +292,21 @@
                     <button type="submit" class="btn btn-primary">Download Artifacts</button>
                 </form>
                 {% if is_witness_test %}
-                <button type="button" class="btn btn-outline-secondary"
-                        data-bs-toggle="modal" data-bs-target="#powerChartModal"
-                        data-report-url="{{ url_for('admin_run_html_report_page' if is_admin_view else 'run_html_report_page', run_id=run_id) }}">
-                    View Device Power Chart
-                </button>
+                <details>
+                    <summary class="btn btn-outline-secondary">View Device Power Chart</summary>
+                    <form action="{{ url_for('admin_run_html_report_page' if is_admin_view else 'run_html_report_page', run_id=run_id) }}"
+                          method="GET" target="_blank"
+                          class="mt-2 p-3 border rounded bg-light d-flex flex-column gap-2" style="width: 280px;">
+                        <p class="mb-1 small">Optionally align the time axis to a video recording. Enter the video timestamp (MM:SS) at which the test started.</p>
+                        <div class="d-flex align-items-center gap-2">
+                            <label class="form-label mb-0 text-nowrap small" for="powerChartVideoStart">Video timestamp:</label>
+                            <input type="text" id="powerChartVideoStart" name="video_start"
+                                   class="form-control form-control-sm" style="width:90px;"
+                                   placeholder="MM:SS" autocomplete="off">
+                        </div>
+                        <button type="submit" class="btn btn-outline-secondary btn-sm align-self-start">Open Report</button>
+                    </form>
+                </details>
                 {% endif %}
             </div>
         </div>


### PR DESCRIPTION
WARNING: Must be deployed alongside the incoming orchestrator PR, as the new endpoint to retrieve the html power limit report must be on both sides.

WARNING-2: I remove the auto-generation of the run_artefact at the end of runs, forcing users to click generate artefact if they want it. I am super happy to undo that, but did it for a couple reasons: 1) remove the timeout and forced download on playlist transitions to speed up the flow. 2) removes the wierd issue of the special case finalise but get no data, decouples the two functions better.