### PR TITLE
Decouple UI from test defs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,7 @@ dependencies = [
     "authlib",
     "requests",
     "pyjwt",
-    "cactus-schema>=0.0.18",
-    "cactus-test-definitions",  # used only for determining witness test class membership for HTML report display
+    "cactus-schema>=0.0.19",
 ]
 
 

--- a/src/cactus_ui/server.py
+++ b/src/cactus_ui/server.py
@@ -584,6 +584,10 @@ def admin_run_status_page(access_token: str, run_id: str) -> str | Response:
     else:
         initial_status_b64 = ""
 
+    playlist_info, next_playlist_run_id, current_active_run = (
+        _build_playlist_info(access_token, run_response, admin=True) if run_response else (None, None, None)
+    )
+
     return render_template(
         "run_status.html",
         run_is_live=run_is_live,
@@ -594,7 +598,9 @@ def admin_run_status_page(access_token: str, run_id: str) -> str | Response:
         run_test_uri=run_test_uri,
         run_procedure_id=run_procedure_id,
         error=error,
-        playlist_info=None,
+        playlist_info=playlist_info,
+        next_playlist_run_id=next_playlist_run_id,
+        current_active_run=current_active_run,
         is_admin_view=True,
         is_witness_test=is_witness_test(run_response),
         user_buttons_state="disabled",
@@ -1243,7 +1249,7 @@ def past_playlist_sessions_json(access_token: str, run_group_id: int) -> Respons
 
 
 def _build_playlist_info(
-    access_token: str, run_response: schema.RunResponse
+    access_token: str, run_response: schema.RunResponse, admin: bool = False
 ) -> tuple[dict | None, int | None, dict | None]:
     """Build playlist template context from a run that belongs to a playlist.
 
@@ -1252,13 +1258,14 @@ def _build_playlist_info(
     if not run_response.playlist_runs:
         return None, None, None
 
+    fetch_run = orchestrator.admin_fetch_individual_run if admin else orchestrator.fetch_individual_run
     current_order = run_response.playlist_order
     active_playlist_session = session.get("active_playlist", {})
 
     playlist_runs_full: list[dict] = []
     first_run_started_at = None
     for i, r in enumerate(run_response.playlist_runs):
-        full_run = orchestrator.fetch_individual_run(access_token, str(r.run_id))
+        full_run = fetch_run(access_token, str(r.run_id))
         if full_run:
             if i == 0:
                 first_run_started_at = full_run.created_at.isoformat() if full_run.created_at else None

--- a/src/cactus_ui/server.py
+++ b/src/cactus_ui/server.py
@@ -18,9 +18,6 @@ from typing import Any, Callable, TypeVar, cast
 from urllib.parse import quote_plus, urlencode
 from cactus_schema.orchestrator.compliance import fetch_compliance_classes
 
-# cactus_test_definitions is imported only for witness test class membership used in HTML report display
-from cactus_test_definitions.client.test_procedures import get_all_test_procedures
-
 import cactus_schema.orchestrator as schema
 import jwt
 from authlib.integrations.flask_client import OAuth
@@ -55,23 +52,10 @@ else:
 logger = logging.getLogger(__name__)
 
 _WITNESS_CLASSES = frozenset({"DER-A", "DER-G", "DER-L", "DR-D", "DR-G", "DR-L"})
-_WITNESS_PROCEDURE_IDS: frozenset[str] = frozenset(
-    str(pid) for pid, tp in get_all_test_procedures().items() if _WITNESS_CLASSES & set(tp.classes)
-)
 
-_IMMEDIATE_START_IDS: frozenset[str] = frozenset(
-    str(pid)
-    for pid, tp in get_all_test_procedures().items()
-    if tp.preconditions is not None and tp.preconditions.immediate_start
-)
 
-# Category and test ordering derived from local definition order (used to sort playlist builder display)
-_CATEGORY_ORDER: dict[str, int] = {}
-_TEST_ORDER: dict[str, int] = {}
-for _i, (_pid, _tp) in enumerate(get_all_test_procedures().items()):
-    if _tp.category not in _CATEGORY_ORDER:
-        _CATEGORY_ORDER[_tp.category] = len(_CATEGORY_ORDER)
-    _TEST_ORDER[str(_pid)] = _i
+def is_witness_test(run_response: schema.RunResponse | None) -> bool:
+    return bool(_WITNESS_CLASSES & set(run_response.classes or [])) if run_response else False
 
 
 ENV_FILE = find_dotenv()
@@ -260,12 +244,11 @@ def build_playlist_tests_by_category(
 ) -> dict[str, list[dict]]:
     """Build ordered category→tests dict for the playlist builder, excluding immediate_start procedures.
 
-    Categories and tests within each category are sorted by local definition order so the display
-    is consistent regardless of the order the orchestrator returns procedures.
+    Procedures are expected to arrive in definition order from the orchestrator; insertion order is preserved.
     """
     result: dict[str, list[dict]] = {}
     for p in procedures:
-        if str(p.test_procedure_id) in _IMMEDIATE_START_IDS:
+        if p.immediate_start:
             continue
         cat = p.category
         if cat not in result:
@@ -274,14 +257,11 @@ def build_playlist_tests_by_category(
             {
                 "id": str(p.test_procedure_id),
                 "description": p.description,
-                "is_witness": str(p.test_procedure_id) in _WITNESS_PROCEDURE_IDS,
+                "is_witness": bool(_WITNESS_CLASSES & set(p.classes or [])),
                 "classes": p.classes or [],
             }
         )
-    # Sort categories and tests within each category by local definition order
-    for cat in result:
-        result[cat].sort(key=lambda t: _TEST_ORDER.get(t["id"], 999))
-    return dict(sorted(result.items(), key=lambda x: _CATEGORY_ORDER.get(x[0], 999)))
+    return result
 
 
 def build_test_status_dict(run: schema.RunResponse) -> dict:
@@ -616,7 +596,7 @@ def admin_run_status_page(access_token: str, run_id: str) -> str | Response:
         error=error,
         playlist_info=None,
         is_admin_view=True,
-        is_witness_test=run_procedure_id in _WITNESS_PROCEDURE_IDS,
+        is_witness_test=is_witness_test(run_response),
         user_buttons_state="disabled",
         proceed_uri=url_for("admin_send_proceed", run_id=run_id),
         cactus_platform_support_email=CACTUS_PLATFORM_SUPPORT_EMAIL,
@@ -1418,7 +1398,7 @@ def run_status_page(access_token: str, run_id: str) -> str | Response:
         next_playlist_run_id=next_playlist_run_id,
         current_active_run=current_active_run,
         is_admin_view=False,
-        is_witness_test=run_procedure_id in _WITNESS_PROCEDURE_IDS,
+        is_witness_test=is_witness_test(run_response),
         proceed_uri=url_for("send_proceed", run_id=run_id),
         cactus_platform_support_email=CACTUS_PLATFORM_SUPPORT_EMAIL,
     )

--- a/src/cactus_ui/templates/run_status.html
+++ b/src/cactus_ui/templates/run_status.html
@@ -285,15 +285,15 @@
         <div class="alert alert-primary" role="alert">
             <p>This run has been finalised and is no longer active.</p>
 
-            <p>Click below to download the run's artifacts{% if is_witness_test %} or view the Device Power Chart{% endif %}.</p>
+            <p>Click below to download the run's artifacts{% if not is_immediate_start %} or view the Active Power Chart{% endif %}.</p>
             <div class="d-flex gap-2 flex-wrap">
                 <form id='download-form' method="POST" action="{{ url_for('admin_run_status_page', run_id=run_id) if is_admin_view else url_for('run_status_page', run_id=run_id) }}">
                     <input type="hidden" name="action" value="artifact">
                     <button type="submit" class="btn btn-primary">Download Artifacts</button>
                 </form>
-                {% if is_witness_test %}
+                {% if not is_immediate_start %}
                 <details>
-                    <summary class="btn btn-outline-secondary">Witness Test Chart</summary>
+                    <summary class="btn btn-outline-secondary">Active Power Chart</summary>
                     <form action="{{ url_for('admin_run_html_report_page' if is_admin_view else 'run_html_report_page', run_id=run_id) }}"
                           method="GET" target="_blank"
                           class="mt-2 p-3 border rounded bg-light d-flex flex-column gap-2" style="width: 280px;">


### PR DESCRIPTION
Should deploy alongside the support from orchestrator (same PR name)

Also includes a bugfix to make sure that the active power chart is shown on playlist runs where relevant. 