### PR TITLE
Stats page tests axis

### DIFF
--- a/src/cactus_ui/server.py
+++ b/src/cactus_ui/server.py
@@ -339,11 +339,13 @@ def admin_stats_page(access_token: str) -> str:
             month_key = week_str
             month_display = week_str
             year_display = ""
-        week_bars.append({
-            "month": month_display if month_key != last_month else "",
-            "year": year_display if year_display != last_year else "",
-            "count": count,
-        })
+        week_bars.append(
+            {
+                "month": month_display if month_key != last_month else "",
+                "year": year_display if year_display != last_year else "",
+                "count": count,
+            }
+        )
         last_month = month_key
         last_year = year_display
 

--- a/src/cactus_ui/server.py
+++ b/src/cactus_ui/server.py
@@ -326,16 +326,26 @@ def admin_stats_page(access_token: str) -> str:
 
     # Build weekly bars; x-axis label shows month only when it changes
     week_bars: list[dict] = []
-    last_month = None
+    last_month: str | None = None
+    last_year: str | None = None
     for week_str, count in sorted(stats.runs_per_week.items()):
         try:
-            year_s, week_s = week_str.split("-W")
-            dt = datetime.strptime(f"{year_s}-W{int(week_s):02d}-1", "%G-W%V-%u")
-            month_label = dt.strftime("%b %Y")
+            yr_s, wk_s = week_str.split("-W")
+            dt = datetime.strptime(f"{yr_s}-W{int(wk_s):02d}-1", "%G-W%V-%u")
+            month_key = dt.strftime("%b %Y")
+            month_display = dt.strftime("%b")
+            year_display = dt.strftime("%Y")
         except (ValueError, AttributeError):
-            month_label = week_str
-        week_bars.append({"label": month_label if month_label != last_month else "", "count": count})
-        last_month = month_label
+            month_key = week_str
+            month_display = week_str
+            year_display = ""
+        week_bars.append({
+            "month": month_display if month_key != last_month else "",
+            "year": year_display if year_display != last_year else "",
+            "count": count,
+        })
+        last_month = month_key
+        last_year = year_display
 
     # Sort procedures by total_runs descending (all procedures are returned, not just top 20)
     procedures = sorted(stats.procedures, key=lambda p: p.get("total_runs", 0), reverse=True)

--- a/src/cactus_ui/server.py
+++ b/src/cactus_ui/server.py
@@ -324,16 +324,18 @@ def admin_stats_page(access_token: str) -> str:
         for name, count in sorted(stats.runs_per_user.items(), key=lambda x: x[1], reverse=True)
     ]
 
-    # Sort runs_per_week by week key and convert week key to label
-    def _week_label(week_str: str) -> str:
+    # Build weekly bars; x-axis label shows month only when it changes
+    week_bars: list[dict] = []
+    last_month = None
+    for week_str, count in sorted(stats.runs_per_week.items()):
         try:
             year_s, week_s = week_str.split("-W")
             dt = datetime.strptime(f"{year_s}-W{int(week_s):02d}-1", "%G-W%V-%u")
-            return dt.strftime("%-d %b")
+            month_label = dt.strftime("%b %Y")
         except (ValueError, AttributeError):
-            return week_str
-
-    runs_per_week = {_week_label(k): v for k, v in sorted(stats.runs_per_week.items())}
+            month_label = week_str
+        week_bars.append({"label": month_label if month_label != last_month else "", "count": count})
+        last_month = month_label
 
     # Sort procedures by total_runs descending (all procedures are returned, not just top 20)
     procedures = sorted(stats.procedures, key=lambda p: p.get("total_runs", 0), reverse=True)
@@ -349,7 +351,7 @@ def admin_stats_page(access_token: str) -> str:
         user_leaderboard=user_leaderboard,
         procedures=procedures,
         max_run_number=stats.max_run_id,
-        runs_per_week=runs_per_week,
+        runs_per_week=week_bars,
     )
 
 

--- a/src/cactus_ui/templates/admin_stats.html
+++ b/src/cactus_ui/templates/admin_stats.html
@@ -119,14 +119,15 @@
                 {% if bar_h < 2 %}{% set bar_h = 2 %}{% endif %}
                 <div class="d-flex flex-column align-items-center flex-fill" style="min-width: 0;">
                     <small class="text-muted" style="font-size: 0.6rem; line-height: 1.2;">{{ bar.count }}</small>
-                    <div class="w-100 bg-success rounded-top" style="height: {{ bar_h }}px;" title="{{ bar.label or '' }}: {{ bar.count }} runs"></div>
+                    <div class="w-100 bg-success rounded-top" style="height: {{ bar_h }}px;" title="{{ bar.month }} {{ bar.year }}: {{ bar.count }} runs"></div>
                 </div>
                 {% endfor %}
             </div>
             <div class="d-flex" style="gap: 2px; margin-top: 3px; border-top: 1px solid #dee2e6;">
                 {% for bar in runs_per_week %}
                 <div class="text-center flex-fill" style="min-width: 0;">
-                    <small class="text-muted text-truncate d-block" style="font-size: 0.6rem;">{{ bar.label }}</small>
+                    <small class="text-muted text-truncate d-block" style="font-size: 0.6rem;">{{ bar.month }}</small>
+                    <small class="text-muted text-truncate d-block" style="font-size: 0.6rem;">{{ bar.year }}</small>
                 </div>
                 {% endfor %}
             </div>

--- a/src/cactus_ui/templates/admin_stats.html
+++ b/src/cactus_ui/templates/admin_stats.html
@@ -50,10 +50,10 @@
         <div class="col-md-3 mb-3">
             <div class="card shadow-sm border-start border-4 border-warning">
                 <div class="card-body text-center py-3">
-                    <i class="fas fa-check-circle text-warning mb-2" style="font-size: 1.4rem;"></i>
-                    <div class="fs-2 fw-bold">{{ total_passed }}</div>
-                    <div class="text-muted small">Currently Passing</div>
-                    <div class="text-muted" style="font-size: 0.7rem;">latest run per procedure per group</div>
+                    <i class="fas fa-user-clock text-warning mb-2" style="font-size: 1.4rem;"></i>
+                    <div class="fs-2 fw-bold">{{ ((total_runs / total_users) | round(1)) if total_users > 0 else '—' }}</div>
+                    <div class="text-muted small">Avg Runs per User</div>
+                    <div style="font-size: 0.7rem;">&nbsp;</div>
                 </div>
             </div>
         </div>

--- a/src/cactus_ui/templates/admin_stats.html
+++ b/src/cactus_ui/templates/admin_stats.html
@@ -109,24 +109,24 @@
 
     <!-- Runs Per Week -->
     {% if runs_per_week %}
-    {% set max_week_runs = runs_per_week.values() | max if runs_per_week.values() | list | length > 0 else 1 %}
+    {% set max_week_runs = (runs_per_week | map(attribute='count') | list | max) if runs_per_week | length > 0 else 1 %}
     <div class="card shadow-sm mb-4">
         <div class="card-header fw-bold"><i class="fas fa-calendar-week me-2"></i>Tests Per Week</div>
         <div class="card-body py-2">
             <div class="d-flex align-items-end" style="gap: 2px; height: 110px;">
-                {% for week, count in runs_per_week.items() %}
-                {% set bar_h = (count / max_week_runs * 80) | int %}
+                {% for bar in runs_per_week %}
+                {% set bar_h = (bar.count / max_week_runs * 80) | int %}
                 {% if bar_h < 2 %}{% set bar_h = 2 %}{% endif %}
                 <div class="d-flex flex-column align-items-center flex-fill" style="min-width: 0;">
-                    <small class="text-muted" style="font-size: 0.6rem; line-height: 1.2;">{{ count }}</small>
-                    <div class="w-100 bg-success rounded-top" style="height: {{ bar_h }}px;" title="{{ week }}: {{ count }} runs"></div>
+                    <small class="text-muted" style="font-size: 0.6rem; line-height: 1.2;">{{ bar.count }}</small>
+                    <div class="w-100 bg-success rounded-top" style="height: {{ bar_h }}px;" title="{{ bar.label or '' }}: {{ bar.count }} runs"></div>
                 </div>
                 {% endfor %}
             </div>
             <div class="d-flex" style="gap: 2px; margin-top: 3px; border-top: 1px solid #dee2e6;">
-                {% for week, count in runs_per_week.items() %}
+                {% for bar in runs_per_week %}
                 <div class="text-center flex-fill" style="min-width: 0;">
-                    <small class="text-muted text-truncate d-block" style="font-size: 0.6rem;">{{ week }}</small>
+                    <small class="text-muted text-truncate d-block" style="font-size: 0.6rem;">{{ bar.label }}</small>
                 </div>
                 {% endfor %}
             </div>


### PR DESCRIPTION
Fix the axis down the bottom of runs per week (was too squished to read with labels by week)
Add average runs per user instead of number of runs (was redundant info)
<img width="2380" height="1277" alt="image" src="https://github.com/user-attachments/assets/84cfe8a7-5910-4db7-b758-b55fbbb32e1f" />
