### PR TITLE
show better hover time

### DIFF
--- a/src/cactus_ui/templates/run_status.html
+++ b/src/cactus_ui/templates/run_status.html
@@ -1509,7 +1509,12 @@
                             common: { drawTime: 'beforeDraw' },
                             annotations
                         },
-                        legend: { display: datasets.length > 0 }
+                        legend: { display: datasets.length > 0 },
+                        tooltip: {
+                            callbacks: {
+                                title: items => items.length ? formatTimeLabel(Math.floor(items[0].parsed.x)) : ''
+                            }
+                        }
                     },
                     scales: {
                         x: {


### PR DESCRIPTION
On hover, time appears formatted into minutes and seconds not just seconds since test start.