### PR TITLE
run-not-found-page

### DIFF
--- a/src/cactus_ui/server.py
+++ b/src/cactus_ui/server.py
@@ -54,6 +54,9 @@ logger = logging.getLogger(__name__)
 _WITNESS_CLASSES = frozenset({"DER-A", "DER-G", "DER-L", "DR-D", "DR-G", "DR-L"})
 ACTIVE_RUN_STATUSES = [1, 2, 6]  # initialized, started, provisioning
 FINALIZED_RUN_STATUSES = [3, 4]  # finalized by user, finalized by timeout
+_ACTIVE_RUN_STATUSES = frozenset(
+    {schema.RunStatusResponse.initialised, schema.RunStatusResponse.started, schema.RunStatusResponse.provisioning}
+)
 
 
 def is_witness_test(run_response: schema.RunResponse | None) -> bool:
@@ -585,7 +588,6 @@ def admin_run_status_page(access_token: str, run_id: str) -> str | Response:
                 )
 
     status = orchestrator.admin_fetch_run_status(access_token=access_token, run_id=run_id)
-    run_is_live = status is not None
 
     run_status = None
     run_test_uri = None
@@ -598,6 +600,8 @@ def admin_run_status_page(access_token: str, run_id: str) -> str | Response:
         run_test_uri = run_response.test_url
         run_procedure_id = run_response.test_procedure_id
         run_has_artifacts = run_response.has_artifacts
+
+    run_is_live = status is not None or (run_response is not None and run_response.status in _ACTIVE_RUN_STATUSES)
 
     # Take the big JSON response string and encode it using base64 so we can embed it in the template and re-hydrate
     # it easily enough
@@ -1419,7 +1423,6 @@ def run_status_page(access_token: str, run_id: str) -> str | Response:
             error = result
 
     status = orchestrator.fetch_run_status(access_token=access_token, run_id=run_id)
-    run_is_live = status is not None
 
     run_status = None
     run_test_uri = None
@@ -1432,6 +1435,8 @@ def run_status_page(access_token: str, run_id: str) -> str | Response:
         run_test_uri = run_response.test_url
         run_procedure_id = run_response.test_procedure_id
         run_has_artifacts = run_response.has_artifacts
+
+    run_is_live = status is not None or (run_response is not None and run_response.status in _ACTIVE_RUN_STATUSES)
 
     initial_status_b64 = b64encode(status.encode()).decode() if status is not None else ""
 

--- a/src/cactus_ui/server.py
+++ b/src/cactus_ui/server.py
@@ -52,8 +52,10 @@ else:
 logger = logging.getLogger(__name__)
 
 _WITNESS_CLASSES = frozenset({"DER-A", "DER-G", "DER-L", "DR-D", "DR-G", "DR-L"})
-ACTIVE_RUN_STATUSES = [1, 2, 6]  # initialized, started, provisioning
-FINALIZED_RUN_STATUSES = [3, 4]  # finalized by user, finalized by timeout
+# Integer status codes used by TestProcedureRunSummaryResponse.latest_run_status (not a RunStatusResponse enum)
+_ACTIVE_RUN_STATUS_INTS = [1, 2, 6]  # initialised, started, provisioning
+_FINALIZED_RUN_STATUS_INTS = [3, 4]  # finalised by user, finalised by timeout
+# RunStatusResponse enum values used by RunResponse.status
 _ACTIVE_RUN_STATUSES = frozenset(
     {schema.RunStatusResponse.initialised, schema.RunStatusResponse.started, schema.RunStatusResponse.provisioning}
 )
@@ -227,11 +229,11 @@ def download_playlist_artifacts(access_token: str, run_ids: list[int], download_
 def run_summary_to_compliance_status(
     test_procedure: schema.TestProcedureRunSummaryResponse,
 ) -> str:
-    if test_procedure.latest_run_status in ACTIVE_RUN_STATUSES:
+    if test_procedure.latest_run_status in _ACTIVE_RUN_STATUS_INTS:
         return "active"
     elif test_procedure.run_count == 0:
         return "runless"
-    elif test_procedure.latest_run_status in FINALIZED_RUN_STATUSES:
+    elif test_procedure.latest_run_status in _FINALIZED_RUN_STATUS_INTS:
         if test_procedure.latest_all_criteria_met:
             return "success"
         else:

--- a/src/cactus_ui/templates/run_status.html
+++ b/src/cactus_ui/templates/run_status.html
@@ -273,7 +273,12 @@
 
 <div class="row justify-content-center">
     <div class="status-container">
-        {% if run_status == 'skipped' %}
+        {% if run_status is none %}
+        <h2>Run {{ run_id }} Not Found</h2>
+        <div class="alert alert-danger" role="alert">
+            <p>Run <strong>{{ run_id }}</strong> does not exist.</p>
+        </div>
+        {% elif run_status == 'skipped' %}
         <h2>Run {{ run_id }} [Skipped]</h2>
         <div class="alert alert-secondary" role="alert">
             <p>This run was skipped as part of a playlist and was never executed.</p>


### PR DESCRIPTION
Two issues;
1) Adding in URIs that didnt exist: https://cactus.cecs.anu.edu.au/admin/run/99999999 would show run finalised, artefact not found. Now shows run does not exist.

2) If running status failed or hung for a while, the UI could think the run was not active and a page refresh would incorrectly show run finalised despite still running. Now we check the actual status returned by runner (cached) too.