### PR TITLE
precondition hide, all runs tick on bottom banner

### DIFF
--- a/src/cactus_ui/templates/run_status.html
+++ b/src/cactus_ui/templates/run_status.html
@@ -780,6 +780,13 @@
         return fragments
     }
 
+    function updateBannerAllComplete(criteria) {
+        const el = document.getElementById('banner-all-complete');
+        if (!el) return;
+        const allComplete = criteria.some(c => c.type === 'all-steps-complete' && c.success);
+        el.style.display = allComplete ? '' : 'none';
+    }
+
     function updateBannerStep(stepStatus) {
         const el = document.getElementById('banner-step');
         if (!el) return;
@@ -1682,15 +1689,19 @@
             initialisedCard.innerHTML = initialisedCardBody(instructions);
         }
 
-        // update precondition checks table
-        const preconditionChecksTable = document.getElementById('update-precondition-checks-table');
-        const preconditionChecks = status.precondition_checks ?? null;
-        if (preconditionChecks) {
-            preconditionChecksTable.innerHTML = preconditionChecksTableBody(preconditionChecks);
-        } else {
-            // If there aren't any precondition checks we remove the card entirely.
-            const preconditionCard = document.getElementById('precondition-checks-card');
-            if (preconditionCard) preconditionCard.remove();
+        // update precondition checks table - only visible during init phase
+        const preconditionCard = document.getElementById('precondition-checks-card');
+        if (preconditionCard) {
+            if (status.timestamp_start) {
+                preconditionCard.style.display = 'none';
+            } else {
+                const preconditionChecks = status.precondition_checks ?? null;
+                if (preconditionChecks) {
+                    document.getElementById('update-precondition-checks-table').innerHTML = preconditionChecksTableBody(preconditionChecks);
+                } else {
+                    preconditionCard.remove();
+                }
+            }
         }
 
         // update cactus log entries
@@ -1704,6 +1715,7 @@
         const stepsTable = document.getElementById('update-steps-table');
         stepsTable.innerHTML = stepStatusTableBody(status.step_status ?? {}, status.timestamp_start).join("");
         updateBannerStep(status.step_status ?? {});
+        updateBannerAllComplete(status.criteria ?? []);
 
         // update criteria table (append synthetic XSD validity criteria)
         const criteria = status.criteria ?? [];
@@ -1973,6 +1985,7 @@
     <span><i class="fas fa-clock"></i> <span id="banner-clock">--:--:--</span></span>
     <span style="color:#6c757d;">|</span>
     <span id="banner-step" style="color:#adb5bd;">No active step</span>
+    <span id="banner-all-complete" style="display:none;margin-left:auto;"><i class="fas fa-check-circle" style="color:#28a745;"></i> All steps complete</span>
 </div>
 {% endif %}
 

--- a/src/cactus_ui/templates/runs.html
+++ b/src/cactus_ui/templates/runs.html
@@ -297,16 +297,19 @@
         if (!has_artifacts) return "";
 
         if (isAdminView) {
+            // admin shouldn't be starting or finalizing tests for other users, so the
+            // action buttons are shown disabled. Download remains functional.
             switch (run_status) {
                 case "initialised":
+                    return `<form method="POST" action="{{ url_for('admin_group_runs_page', run_group_id=run_group_id) }}">
+                    <input type="hidden" name="run_id" value="${run_id}">
+                    <button disabled type="submit" class="btn btn-primary">Start</button>
+                </form>`;
                 case "started":
-                        // admin shouldn't be starting or finalizing tests for other users.
-                        // button is disabled
-                        return `<form method="POST" action="{{ url_for('group_runs_page', run_group_id=run_group_id) }}">
-                        <input type="hidden" name="run_id" value="${run_id}">
-                        <input type="hidden" name="action" value="artifact">
-                        <button disabled type="submit" class="btn btn-secondary">Running...</button>
-                    </form>`;
+                    return `<form method="POST" action="{{ url_for('admin_group_runs_page', run_group_id=run_group_id) }}">
+                    <input type="hidden" name="run_id" value="${run_id}">
+                    <button disabled type="submit" class="btn btn-warning">Finalise</button>
+                </form>`;
                 default:
                     return `<form method="POST" action="{{ url_for('admin_group_runs_page', run_group_id=run_group_id) }}">
                     <input type="hidden" name="run_id" value="${run_id}">
@@ -455,12 +458,12 @@
             // handle the other test procedure buttons
             document.getElementById("runs-title").innerHTML = `<a href="/procedure/${test_procedure_id}">${test_procedure_id}</a> ${description}`;
 
-            const hidden = isAdminView ? "hidden" : ""
+            const adminDisabled = isAdminView ? "disabled" : ""
             document.getElementById("runs-actions").innerHTML = `
             <form method="POST" action="{{ url_for('group_runs_page', run_group_id=run_group_id) }}">
                 <input type="hidden" name="test_procedure_id" value="${test_procedure_id}">
                 <input type="hidden" name="action" value="initialise">
-                <button ${hidden} type="submit" class="btn btn-primary" onclick="handleButtonClick(event)">New Test Run</button>
+                <button ${adminDisabled} type="submit" class="btn btn-primary" onclick="handleButtonClick(event)">New Test Run</button>
                 <small class="text-muted d-block mt-1">May take up to 30s to initialize</small>
             </form>`;
 


### PR DESCRIPTION
1) Hides preconditions after a run starts (fixes bug where preconditions are met, test starts, preconditions re-evaluate due to test change, and get marked as failed, confusing the user).
2) Bottom banner on runs now has a green tick when all test steps are green. Useful for witness testers.
3) Admin view of runs now shows the start/finalise buttons so witness testers see what users see.